### PR TITLE
Add the i18n global

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ wp.data
 wp.hooks
 wp.blocks
 wp.domReady
+wp.i18n
 ```
 
 If your block plugin relies on other variables not available at the moment, please do open an issue on the repository to ask for inclusion.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "blockbook-cli",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"@wordpress/element": "^2.16.0",
 		"@wordpress/format-library": "^1.22.2",
 		"@wordpress/hooks": "^2.9.0",
+		"@wordpress/i18n": "^3.14.0",
 		"@wordpress/icons": "^2.4.0",
 		"@wordpress/postcss-plugins-preset": "^1.3.1",
 		"babel-loader": "^8.1.0",

--- a/src/app/globals/index.js
+++ b/src/app/globals/index.js
@@ -2,6 +2,7 @@
 import * as data from '@wordpress/data';
 import * as hooks from '@wordpress/hooks';
 import * as blocks from '@wordpress/blocks';
+import * as i18n from '@wordpress/i18n';
 import domReady from '@wordpress/dom-ready';
 
 window.wp = {
@@ -9,4 +10,5 @@ window.wp = {
 	hooks,
 	blocks,
 	domReady,
+	i18n,
 };


### PR DESCRIPTION
Just makes the wp.i18n available on blockbook.

closes #19 