### PR TITLE
use actuall block markup for the storie previews

### DIFF
--- a/src/app/components/block-stories/index.js
+++ b/src/app/components/block-stories/index.js
@@ -1,19 +1,26 @@
-import { getBlockFromExample } from '@wordpress/blocks';
-import { BlockPreview } from '@wordpress/block-editor';
+import { getBlockFromExample, serialize } from '@wordpress/blocks';
 import './style.css';
 
 export function BlockStories( { stories } ) {
+	function getBlockMarkup( blockStory ) {
+		return serialize(
+			blockStory.blocks.map( ( childBlock ) =>
+				getBlockFromExample( childBlock.name, childBlock )
+			)
+		);
+	}
+
 	return (
 		<div className="bb-route-block__stories">
 			{ stories.map( ( blockStory ) => (
 				<div key={ blockStory.name }>
 					<h3>{ blockStory.name }</h3>
-					<BlockPreview
-						viewportWidth={ 1000 }
-						blocks={ blockStory.blocks.map( ( childBlock ) =>
-							getBlockFromExample( childBlock.name, childBlock )
-						) }
-					/>
+					<div
+						className="bb-route-block__stories--preview"
+						dangerouslySetInnerHTML={ {
+							__html: getBlockMarkup( blockStory ),
+						} }
+					></div>
 				</div>
 			) ) }
 		</div>


### PR DESCRIPTION
While working with the BlockBook I came across an issue where I had no way of checking the actually markup produced by the blocks ( within the `save` method ).

I'm sure there was a reason behind you using the `BlockPreview` component, but I would love to know what that is, and wether you see a place for something like what I did in this pr? 