### PR TITLE
Add empty favicon to prevent `404` error in Firefox dev console

### DIFF
--- a/src/app/index.html
+++ b/src/app/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>BlockBook</title>
+    <link rel="icon" href="data:,">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Firefox [automatically requests a favicon](https://bugzilla.mozilla.org/show_bug.cgi?id=260500), even if a site's HTML doesn't declare one. If the site doesn't have one, that request results in a `404`, which creates an error in the dev console. That false error can be distracting to devs who are making changes to a block and watching for errors.

Unfortunately, Firefox doesn't provide a good way to disable that behavior, so the standard workaround is to [add a null favicon](https://stackoverflow.com/a/38917888/450127).